### PR TITLE
fix legacy auth for k8s

### DIFF
--- a/infra/cluster-1/main.tf
+++ b/infra/cluster-1/main.tf
@@ -26,6 +26,8 @@ resource "google_container_cluster" "k8s" {
 
   initial_node_count = "${var.num_nodes}"
 
+  enable_legacy_abac = "true"
+
   master_auth {
     username = "${var.master_auth_username}"
     password = "${var.master_auth_password}"


### PR DESCRIPTION
применил старые права для кластера, позволит запустить простую версию gitlab-omnibus - что бы не городить полную версию