### PR TITLE
fix gitlab dns name for ingress

### DIFF
--- a/cicd/gitlab/templates/gitlab-config.yaml
+++ b/cicd/gitlab/templates/gitlab-config.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   external_scheme: http
-  external_hostname: gitlab.{{ .Values.baseDomain }}
+  external_hostname: {{ template "fullname" . }}
   registry_external_scheme: https
   registry_external_hostname: registry.{{ .Values.baseDomain }}
   mattermost_external_scheme: https


### PR DESCRIPTION
изменил dns имя у гитлаба на человечное, привязанное к реальному домену